### PR TITLE
Komendy serwerowe

### DIFF
--- a/server/src/API/SignalTranslator.cs
+++ b/server/src/API/SignalTranslator.cs
@@ -75,6 +75,14 @@ public class SignalTranslator
             case HostType.CameraSimulator:
                 _logger?.WriteLine(message + $"Forwarding to {nameof(CameraSimulatorAPI)}.", nameof(SignalTranslator));
                 break;
+            case HostType.PuTTYClient:
+                string rawData = string.Empty;
+                foreach (var dataByte in e.Data)
+                    rawData += dataByte;
+                string decodedData = Encoding.UTF8.GetString(e.Data);
+
+                _logger?.WriteLine(message + $"Recognized PuTTY client. Raw = '{rawData}', Decoded = '{decodedData}'.", nameof(SignalTranslator));
+                break;
             case HostType.User:
                 _logger?.WriteLine(message + $"User recognized: {datasender.Name}.", nameof(SignalTranslator));
                 break;

--- a/server/src/API/SignalTranslator.cs
+++ b/server/src/API/SignalTranslator.cs
@@ -1,4 +1,5 @@
 ﻿using ZPIServer.API.CameraLibraries;
+using ZPIServer.Commands;
 using ZPIServer.EventArgs;
 using ZPIServer.Models;
 
@@ -9,10 +10,17 @@ namespace ZPIServer.API;
 /// </summary>
 public class SignalTranslator
 {
+    private readonly Logger _logger;
+
     /// <summary>
     /// Wskazuje czy <see cref="SignalTranslator"/> został uruchomiony i obsługuje inwokacje wydarzenia <see cref="TcpHandler.OnSignalReceived"/>.
     /// </summary>
     public bool IsTranslating { get; private set; } = false;
+
+    public SignalTranslator(Logger logger)
+    {
+        _logger = logger;
+    }
 
     /// <summary>
     /// Rozpoczyna pracę <see cref="SignalTranslator"/>.
@@ -24,7 +32,7 @@ public class SignalTranslator
 
         IsTranslating = true;
         TcpHandler.OnSignalReceived += HandleReceivedSignal;
-        Console.WriteLine($"{nameof(SignalTranslator)} is starting up.");
+        _logger.WriteLine("Starting up.", nameof(SignalTranslator));
     }
 
     /// <summary>
@@ -35,7 +43,7 @@ public class SignalTranslator
         if (!IsTranslating)
             return;
 
-        Console.WriteLine($"Shutting down {nameof(SignalTranslator)}");
+        _logger.WriteLine("Shutting down.", nameof(SignalTranslator));
         TcpHandler.OnSignalReceived -= HandleReceivedSignal;
         IsTranslating = false;
     }
@@ -55,17 +63,17 @@ public class SignalTranslator
             LastKnownStatus = HostDevice.DeviceStatus.Unknown
         };
 
-        Console.Write($"Received {e.Data.Length} bytes of data from {datasender.Type} device. Address = {e.SenderIp}:{e.SenderPort}. ");
+        string message = $"Received {e.Data.Length} bytes of data from {datasender.Type} device. Address = {e.SenderIp}:{e.SenderPort}. ";
         switch (datasender.Type)
         {
             case HostType.Unknown:
-                Console.WriteLine("Ignoring...");
+                _logger.WriteLine(message + "Ignoring...", nameof(SignalTranslator));
                 break;
             case HostType.CameraSimulator:
-                Console.WriteLine($"Forwarding to {nameof(CameraSimulatorAPI)}.");
+                _logger.WriteLine(message + $"Forwarding to {nameof(CameraSimulatorAPI)}.", nameof(SignalTranslator));
                 break;
             case HostType.User:
-                Console.WriteLine($"User recognized: {datasender.Name}.");
+                _logger.WriteLine(message + $"User recognized: {datasender.Name}.", nameof(SignalTranslator));
                 break;
         }
     }

--- a/server/src/API/TcpHandler.cs
+++ b/server/src/API/TcpHandler.cs
@@ -80,6 +80,7 @@ public class TcpHandler
 
     private void HandleConnecitonAsync()
     {
+        Console.WriteLine($"{nameof(TcpHandler)} ready to accept connection on port {((IPEndPoint)_listener.LocalEndpoint).Port}.");
         using (TcpClient incomingClient = _listener.AcceptTcpClient())
         {
             IPEndPoint clientEndPoint = (IPEndPoint)incomingClient.Client.RemoteEndPoint!;
@@ -87,17 +88,15 @@ public class TcpHandler
             int clientPort = clientEndPoint.Port;
             Console.WriteLine($"Accepted connection from {clientAddress}:{clientPort}.");
 
-            using (var stream = incomingClient.GetStream())
+            using var stream = incomingClient.GetStream();
+            int receivedBytesCount;
+            byte[] buffer = new byte[2048];
+            while ((receivedBytesCount = stream.Read(buffer, 0, buffer.Length)) != 0)
             {
-                int receivedBytesCount;
-                byte[] buffer = new byte[2048];
-                while ((receivedBytesCount = stream.Read(buffer, 0, buffer.Length)) != 0)
-                {
-                    Console.WriteLine($"Received {receivedBytesCount} bytes from {clientAddress}:{clientPort} on port {((IPEndPoint)_listener.LocalEndpoint).Port}.");
-                    OnSignalReceived?.Invoke(this, new TcpHandlerEventArgs(clientAddress, clientPort, buffer));
-                }
-                Console.WriteLine($"Closed the connection from {clientAddress}:{clientEndPoint.Port}.");
+                Console.WriteLine($"Received {receivedBytesCount} bytes from {clientAddress}:{clientPort} on port {((IPEndPoint)_listener.LocalEndpoint).Port}.");
+                OnSignalReceived?.Invoke(this, new TcpHandlerEventArgs(clientAddress, clientPort, buffer));
             }
+            Console.WriteLine($"Closed the connection from {clientAddress}:{clientEndPoint.Port}.");
         }
 
         if (_token.IsCancellationRequested)

--- a/server/src/Commands/Command.cs
+++ b/server/src/Commands/Command.cs
@@ -7,7 +7,7 @@ public abstract class Command
     public const string HelpCommand = "help";
     public const string ShutdownCommand = "shutdown";
 
-    public static event EventHandler? OnExecuted;
+    public static event EventHandler<CommandEventArgs>? OnExecuted;
 
     public abstract void Execute();
 

--- a/server/src/Commands/Command.cs
+++ b/server/src/Commands/Command.cs
@@ -4,10 +4,16 @@ namespace ZPIServer.Commands;
 
 public abstract class Command
 {
+    protected readonly Logger _logger;
     public const string HelpCommand = "help";
     public const string ShutdownCommand = "shutdown";
 
     public static event EventHandler<CommandEventArgs>? OnExecuted;
+
+    protected Command(Logger logger)
+    {
+        _logger = logger;
+    }
 
     public abstract void Execute();
 

--- a/server/src/Commands/Command.cs
+++ b/server/src/Commands/Command.cs
@@ -4,13 +4,13 @@ namespace ZPIServer.Commands;
 
 public abstract class Command
 {
-    protected readonly Logger _logger;
+    protected readonly Logger? _logger;
     public const string HelpCommand = "help";
     public const string ShutdownCommand = "shutdown";
 
     public static event EventHandler<CommandEventArgs>? OnExecuted;
 
-    protected Command(Logger logger)
+    protected Command(Logger? logger)
     {
         _logger = logger;
     }

--- a/server/src/Commands/Command.cs
+++ b/server/src/Commands/Command.cs
@@ -1,13 +1,19 @@
-﻿namespace ZPIServer.Commands;
+﻿using ZPIServer.EventArgs;
+
+namespace ZPIServer.Commands;
 
 public abstract class Command
 {
     public const string HelpCommand = "help";
     public const string ShutdownCommand = "shutdown";
 
+    public static event EventHandler? OnExecuted;
+
     public abstract void Execute();
 
     public abstract string GetHelp();
 
     public abstract void SetArguments(params string[]? arguments);
+
+    protected void Invoke(object? sender, CommandEventArgs e) => OnExecuted?.Invoke(sender, e);
 }

--- a/server/src/Commands/Command.cs
+++ b/server/src/Commands/Command.cs
@@ -1,0 +1,13 @@
+﻿namespace ZPIServer.Commands;
+
+public abstract class Command
+{
+    public const string HelpCommand = "help";
+    public const string ShutdownCommand = "shutdown";
+
+    public abstract void Execute();
+
+    public abstract string GetHelp();
+
+    public abstract void SetArguments(params string[]? arguments);
+}

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -7,6 +7,10 @@ public class HelpCommand : Command
 {
     public string? CommandIdentifier { get; private set; }
 
+    public HelpCommand(Logger logger) : base(logger) 
+    { 
+    }
+
     public override void Execute()
     {
         if (CommandIdentifier is not null)
@@ -14,21 +18,21 @@ public class HelpCommand : Command
             switch (CommandIdentifier)
             {
                 case Command.HelpCommand:
-                    Console.WriteLine(GetHelp());
+                    _logger.WriteLine(GetHelp(), null);
                     break;
                 case Command.ShutdownCommand:
-                    Console.WriteLine(new ShutdownCommand().GetHelp());
+                    _logger.WriteLine(new ShutdownCommand(_logger).GetHelp(), null);
                     break;
                 default:
                     CommandIdentifier = null;
-                    Console.WriteLine("Unrecognized command.");
-                    Console.WriteLine(GetAvailableCommands());
+                    _logger.WriteLine("Unrecognized command.", null);
+                    _logger.WriteLine(GetAvailableCommands(), null);
                     break;
             }
         }
         else
         {
-            Console.WriteLine(GetAvailableCommands());
+            _logger.WriteLine(GetAvailableCommands(), null);
         }
         Invoke(this, new CommandEventArgs());
     }
@@ -54,7 +58,7 @@ public class HelpCommand : Command
         }
         else if (arguments.Length > 1)
         {
-            Console.WriteLine("Too many arguments.");
+            _logger.WriteLine("Too many arguments.", null);
         }
     }
 

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -7,7 +7,7 @@ public class HelpCommand : Command
 {
     public string? CommandIdentifier { get; private set; }
 
-    public HelpCommand(Logger logger) : base(logger) 
+    public HelpCommand(Logger? logger = null) : base(logger) 
     { 
     }
 
@@ -18,21 +18,21 @@ public class HelpCommand : Command
             switch (CommandIdentifier)
             {
                 case Command.HelpCommand:
-                    _logger.WriteLine(GetHelp(), null);
+                    _logger?.WriteLine(GetHelp(), null);
                     break;
                 case Command.ShutdownCommand:
-                    _logger.WriteLine(new ShutdownCommand(_logger).GetHelp(), null);
+                    _logger?.WriteLine(new ShutdownCommand(_logger).GetHelp(), null);
                     break;
                 default:
                     CommandIdentifier = null;
-                    _logger.WriteLine("Unrecognized command.", null);
-                    _logger.WriteLine(GetAvailableCommands(), null);
+                    _logger?.WriteLine("Unrecognized command.", null);
+                    _logger?.WriteLine(GetAvailableCommands(), null);
                     break;
             }
         }
         else
         {
-            _logger.WriteLine(GetAvailableCommands(), null);
+            _logger?.WriteLine(GetAvailableCommands(), null);
         }
         Invoke(this, new CommandEventArgs());
     }
@@ -58,7 +58,7 @@ public class HelpCommand : Command
         }
         else if (arguments.Length > 1)
         {
-            _logger.WriteLine("Too many arguments.", null);
+            _logger?.WriteLine("Too many arguments.", null);
         }
     }
 

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -30,7 +30,7 @@ public class HelpCommand : Command
         {
             Console.WriteLine(GetAvailableCommands());
         }
-        Invoke(this, new CommandEventArgs(this));
+        Invoke(this, new CommandEventArgs());
     }
 
     public override string GetHelp()
@@ -43,7 +43,7 @@ public class HelpCommand : Command
         return builder.ToString();
     }
 
-    public override void SetArguments(params string[]? arguments)
+    public override void SetArguments(params string?[]? arguments)
     {
         if (arguments is null)
             return;

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -1,0 +1,19 @@
+﻿namespace ZPIServer.Commands;
+
+public class HelpCommand : Command
+{
+    public override void Execute()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetHelp()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetArguments(params string[]? arguments)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -1,10 +1,12 @@
-﻿namespace ZPIServer.Commands;
+﻿using ZPIServer.EventArgs;
+
+namespace ZPIServer.Commands;
 
 public class HelpCommand : Command
 {
     public override void Execute()
     {
-        throw new NotImplementedException();
+        Invoke(this, new CommandEventArgs(this));
     }
 
     public override string GetHelp()
@@ -14,6 +16,6 @@ public class HelpCommand : Command
 
     public override void SetArguments(params string[]? arguments)
     {
-        throw new NotImplementedException();
+        //TODO
     }
 }

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -1,21 +1,68 @@
-﻿using ZPIServer.EventArgs;
+﻿using System.Text;
+using ZPIServer.EventArgs;
 
 namespace ZPIServer.Commands;
 
 public class HelpCommand : Command
 {
+    public string? CommandIdentifier { get; private set; }
+
     public override void Execute()
     {
+        if (CommandIdentifier is not null)
+        {
+            switch (CommandIdentifier)
+            {
+                case Command.HelpCommand:
+                    Console.WriteLine(GetHelp());
+                    break;
+                case Command.ShutdownCommand:
+                    Console.WriteLine(new ShutdownCommand().GetHelp());
+                    break;
+                default:
+                    CommandIdentifier = null;
+                    Console.WriteLine("Unrecognized command.");
+                    Console.WriteLine(GetAvailableCommands());
+                    break;
+            }
+        }
+        else
+        {
+            Console.WriteLine(GetAvailableCommands());
+        }
         Invoke(this, new CommandEventArgs(this));
     }
 
     public override string GetHelp()
     {
-        throw new NotImplementedException();
+        var builder = new StringBuilder();
+        builder.AppendLine("Shows all available commands.");
+        builder.AppendLine("If entered with the name of a command as argument, it shows the syntax of that command.");
+        builder.AppendLine("Example:");
+        builder.Append("\thelp shutdown");
+        return builder.ToString();
     }
 
     public override void SetArguments(params string[]? arguments)
     {
-        //TODO
+        if (arguments is null)
+            return;
+
+        if (arguments.Length == 1)
+        {
+            CommandIdentifier = arguments[0];
+        }
+        else if (arguments.Length > 1)
+        {
+            Console.WriteLine("Too many arguments.");
+        }
+    }
+
+    private static string GetAvailableCommands()
+    { 
+        var builder = new StringBuilder();
+        builder.AppendLine(Command.HelpCommand + " [command]");
+        builder.Append(Command.ShutdownCommand);
+        return builder.ToString();
     }
 }

--- a/server/src/Commands/Logger.cs
+++ b/server/src/Commands/Logger.cs
@@ -1,0 +1,86 @@
+﻿namespace ZPIServer.Commands;
+
+/// <summary>
+/// Klasa rozszerzająca <see cref="Console"/> o kilka usprawnień organizacyjnych. Przyjmuje i rozpoznaje polecenia użytkownika oraz wyświetla komunikaty wysłane przez inne klasy podczas egzekucji serwera.
+/// </summary>
+public class Logger
+{
+    private readonly CancellationTokenSource _token;
+    private readonly Task _loggerTask;
+
+    public Logger()
+    {
+        _token = new();
+        _loggerTask = new Task(() =>
+        {
+            while (!_token.IsCancellationRequested)
+            {
+            }
+        });
+    }
+
+    /// <summary>
+    /// Przyjmuje linijke z <see cref="Console.ReadLine"/>, rozpoznaje w niej polecenie z argumentami i jeśli polecenie zostanie rozpoznane, wykonuje je.
+    /// </summary>
+    /// <param name="line">Linijka, w której znajduje się polecenie.</param>
+    public void HandleCommand(string? line)
+    {
+        //Sanitize input line
+        if (line is null)
+            return;
+        List<string> words = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        if (words.Count == 0)
+            return;
+
+        //Recognize command
+        Command? command = words[0] switch
+        {
+            Command.HelpCommand => new HelpCommand(this),
+            Command.ShutdownCommand => new ShutdownCommand(this),
+            _ => null
+        };
+        if (command is null)
+        {
+            WriteLine($"Command '{words[0]}' unrecognized. Type '{Command.HelpCommand}' to get all available commands.", null);
+        }
+        words.RemoveAt(0);
+
+        //Execute command
+        command?.SetArguments(words.ToArray());
+        command?.Execute();
+    }
+
+    public void Start() => _loggerTask.Start();
+
+    public void Stop() => _token.Cancel();
+
+    /// <summary>
+    /// Wypisuje nową linijkę z podanym komunikatem w konsoli.
+    /// </summary>
+    /// <param name="message">Linijka do przekazania.</param>
+    /// <param name="callingClass">Nazwa klasy wywołującej metodę. Pojawi się jako prefiks w nawiasach kwadratowych. Podanie wartości <c>null</c> pominie dodawanie prefiksu i wyświetli jedynie <paramref name="message"/>.</param>
+    public void WriteLine(string? message, string? callingClass)
+    {
+        //Remember where the cursor so its position can be restored later
+        int cursorOffset = Console.GetCursorPosition().Left;
+        //Create a new empty line to copy currently entered user input into
+        Console.WriteLine();
+        //Move user input into new line
+        var cursorPosition = Console.GetCursorPosition();
+        if (OperatingSystem.IsWindows()) //supresses CA1416 
+        {
+            Console.MoveBufferArea(0, cursorPosition.Top - 1, Console.BufferWidth, 1, 0, cursorPosition.Top);
+        }
+        //Move cursor to the now empty line above user's input
+        Console.SetCursorPosition(0, cursorPosition.Top - 1);
+        //Clear character that used to be user's input
+        for (int j = 0; j < cursorOffset; j++)
+            Console.Write(' ');
+        Console.SetCursorPosition(0, cursorPosition.Top - 1);
+        //Print the output line  (What will happen if line is so long it would spill into user input???)
+        Console.Write(callingClass is null ? $"{message}" : $"[{callingClass}] {message}");
+        //Move cursor back at the beginning of user's input
+        cursorPosition = Console.GetCursorPosition();
+        Console.SetCursorPosition(cursorOffset, cursorPosition.Top + 1);
+    }
+}

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -1,0 +1,19 @@
+﻿namespace ZPIServer.Commands;
+
+public class ShutdownCommand : Command
+{
+    public override void Execute()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetHelp()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetArguments(params string[]? arguments)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -7,7 +7,7 @@ public class ShutdownCommand : Command
 {
     public override void Execute()
     {
-        Invoke(this, new CommandEventArgs(this));
+        Invoke(this, new CommandEventArgs());
     }
 
     public override string GetHelp()

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -5,6 +5,10 @@ namespace ZPIServer.Commands;
 
 public class ShutdownCommand : Command
 {
+    public ShutdownCommand(Logger logger) : base(logger) 
+    {
+    }
+
     public override void Execute()
     {
         Invoke(this, new CommandEventArgs());

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -1,4 +1,5 @@
-﻿using ZPIServer.EventArgs;
+﻿using System.Text;
+using ZPIServer.EventArgs;
 
 namespace ZPIServer.Commands;
 
@@ -11,11 +12,14 @@ public class ShutdownCommand : Command
 
     public override string GetHelp()
     {
-        throw new NotImplementedException();
+        var builder = new StringBuilder();
+        builder.AppendLine("Stops the server execution.");
+        builder.AppendLine("Example:");
+        builder.Append("\tshutdown");
+        return builder.ToString();
     }
 
     public override void SetArguments(params string[]? arguments)
     {
-        //TODO
     }
 }

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -5,7 +5,7 @@ namespace ZPIServer.Commands;
 
 public class ShutdownCommand : Command
 {
-    public ShutdownCommand(Logger logger) : base(logger) 
+    public ShutdownCommand(Logger? logger = null) : base(logger) 
     {
     }
 

--- a/server/src/Commands/ShutdownCommand.cs
+++ b/server/src/Commands/ShutdownCommand.cs
@@ -1,10 +1,12 @@
-﻿namespace ZPIServer.Commands;
+﻿using ZPIServer.EventArgs;
+
+namespace ZPIServer.Commands;
 
 public class ShutdownCommand : Command
 {
     public override void Execute()
     {
-        throw new NotImplementedException();
+        Invoke(this, new CommandEventArgs(this));
     }
 
     public override string GetHelp()
@@ -14,6 +16,6 @@ public class ShutdownCommand : Command
 
     public override void SetArguments(params string[]? arguments)
     {
-        throw new NotImplementedException();
+        //TODO
     }
 }

--- a/server/src/EventArgs/CommandEventArgs.cs
+++ b/server/src/EventArgs/CommandEventArgs.cs
@@ -1,5 +1,16 @@
-﻿namespace ZPIServer.EventArgs;
+﻿using ZPIServer.Commands;
+
+namespace ZPIServer.EventArgs;
 
 public class CommandEventArgs : System.EventArgs
 {
+    /// <summary>
+    /// Instancja uruchomionej komendy.
+    /// </summary>
+    public Command Command { get; private set; }
+
+    public CommandEventArgs(Command command)
+    {
+        Command = command;
+    }
 }

--- a/server/src/EventArgs/CommandEventArgs.cs
+++ b/server/src/EventArgs/CommandEventArgs.cs
@@ -1,0 +1,5 @@
+﻿namespace ZPIServer.EventArgs;
+
+public class CommandEventArgs : System.EventArgs
+{
+}

--- a/server/src/EventArgs/CommandEventArgs.cs
+++ b/server/src/EventArgs/CommandEventArgs.cs
@@ -1,16 +1,6 @@
-﻿using ZPIServer.Commands;
-
-namespace ZPIServer.EventArgs;
+﻿namespace ZPIServer.EventArgs;
 
 public class CommandEventArgs : System.EventArgs
 {
-    /// <summary>
-    /// Instancja uruchomionej komendy.
-    /// </summary>
-    public Command Command { get; private set; }
-
-    public CommandEventArgs(Command command)
-    {
-        Command = command;
-    }
+    //placeholder
 }

--- a/server/src/EventArgs/TcpHandlerEventArgs.cs
+++ b/server/src/EventArgs/TcpHandlerEventArgs.cs
@@ -1,9 +1,8 @@
-﻿namespace ZPIServer.EventArgs;
+﻿using System.Net;
 
-using System;
-using System.Net;
+namespace ZPIServer.EventArgs;
 
-public class TcpHandlerEventArgs : EventArgs
+public class TcpHandlerEventArgs : System.EventArgs
 {
     /// <summary>
     /// Adres IP urządzenia, od którego otrzymano dane.

--- a/server/src/Models/HostDevice.cs
+++ b/server/src/Models/HostDevice.cs
@@ -36,13 +36,13 @@ public class HostDevice
     //TODO: Integrate into EF Core
     //Fields for both Users and Cameras
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public HostType Type { get; set; }
-    public IPAddress Address { get; set; }
+    public IPAddress? Address { get; set; }
 
     //Camera specific fields
     public int SectorId { get; set; }
     public DeviceStatus LastKnownStatus { get; set; }
     public decimal LastHighestTemperature { get; set; }
-    public string ExactLocation { get; set; }
+    public string? ExactLocation { get; set; }
 }

--- a/server/src/Models/HostType.cs
+++ b/server/src/Models/HostType.cs
@@ -16,7 +16,12 @@ public enum HostType
     CameraSimulator = 1,
 
     /// <summary>
+    /// HostDevice to lokalny klient PuTTY.
+    /// </summary>
+    PuTTYClient = 2,
+
+    /// <summary>
     /// HostDevice to jeden z użytkowników korzystający z aplikacji desktopowej.
     /// </summary>
-    User = 2,
+    User = 3,
 }

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -1,30 +1,49 @@
-﻿using ZPIServer.API;
+﻿using System.Diagnostics;
+using ZPIServer.API;
+using ZPIServer.Commands;
+using ZPIServer.EventArgs;
 
 namespace ZPIServer
 {
-    public class Program
+    public static class Program
     {
         static TcpHandler? tcpHandler;
         static SignalTranslator? signalTranslator;
 
-        static void Main(string[] args)
+
+        public static int Main(string[] args)
         {
             StartServer();
             while (true)
             {
                 //server lifetime loop
+                Console.Write(">> ");
+                string? consoleInput = Console.ReadLine();
+                HandleCommand(consoleInput);
             }
+            StopServer();
+            return 0;
         }
 
-        static void StartServer()
+        private static void StartServer()
         {
+            var stopwatch = Stopwatch.StartNew();
             tcpHandler = new TcpHandler(Settings.ServerAddress, Settings.TcpListeningPort);
             tcpHandler.BeginListening();
             signalTranslator = new SignalTranslator();
             signalTranslator.BeginTranslating();
+            stopwatch.Stop();
+
+            OnCommandExecuted += OnCommandExecutionInvoke;
+
+            Console.WriteLine($"Done! Server took {stopwatch.Elapsed.TotalMilliseconds} milliseconds to start up.");
         }
 
         static void StopServer()
+            command.Execute();
+        }
+
+        private static void StopServer()
         {
             signalTranslator?.StopTranslating();
             tcpHandler?.StopListening();

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -8,6 +8,7 @@ namespace ZPIServer
     public static class Program
     {
         static readonly CancellationTokenSource serverLifetimeToken = new();
+        static readonly Logger logger = new();
 
         static TcpHandler? tcpHandler;
         static SignalTranslator? signalTranslator;
@@ -17,14 +18,14 @@ namespace ZPIServer
             StartServer();
             while (!serverLifetimeToken.IsCancellationRequested)
             {
-                //server lifetime loop
                 Console.Write(">> ");
-                string? consoleInput = Console.ReadLine();
-                HandleCommand(consoleInput);
+                string? input = Console.ReadLine(); //kurwa jego mać Microsoft
+                logger.HandleCommand(input);
             }
             StopServer();
             return 0;
         }
+
         private static void OnCommandExecuted(object? sender, CommandEventArgs e)
         {
             if (sender is not null && sender is ShutdownCommand)
@@ -34,54 +35,27 @@ namespace ZPIServer
         private static void StartServer()
         {
             var stopwatch = Stopwatch.StartNew();
-            tcpHandler = new TcpHandler(Settings.ServerAddress, Settings.TcpListeningPort);
+            logger.Start();
+            tcpHandler = new TcpHandler(Settings.ServerAddress, Settings.TcpListeningPort, logger);
             tcpHandler.BeginListening();
-            signalTranslator = new SignalTranslator();
+            signalTranslator = new SignalTranslator(logger);
             signalTranslator.BeginTranslating();
 
             Command.OnExecuted += OnCommandExecuted;
 
             stopwatch.Stop();
-            Console.WriteLine($"Done! Server took {stopwatch.Elapsed.TotalMilliseconds} milliseconds to start up.");
-        }
-
-        private static void HandleCommand(string? line)
-        {
-            //Sanitize input line
-            if (line is null)
-                return;
-            
-            List<string> words = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
-            if (words.Count == 0)
-                return;
-
-            //Recognize command
-            Command? command = words[0] switch
-            {
-                Command.HelpCommand => new HelpCommand(),
-                Command.ShutdownCommand => new ShutdownCommand(),
-                _ => null
-            };
-
-            if (command is null)
-            {
-                command = new HelpCommand();
-                Console.WriteLine($"Command '{words[0]}' unrecognized.");
-            }
-            words.RemoveAt(0);
-
-            //Execute command
-            command.SetArguments(words.ToArray());
-            command.Execute();
+            logger.WriteLine($"Done! {double.Round(stopwatch.Elapsed.TotalMilliseconds)} milliseconds elapsed.", null);
         }
 
         private static void StopServer()
         {
-            Console.WriteLine("Shutting the server down.");
+            logger?.WriteLine("Shutting the server down.", null);
+            
+            Command.OnExecuted -= OnCommandExecuted;
+
             signalTranslator?.StopTranslating();
             tcpHandler?.StopListening();
-
-            Command.OnExecuted -= OnCommandExecuted;
+            logger?.Stop();
         }
     }
 }

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -7,7 +7,7 @@ namespace ZPIServer
 {
     public static class Program
     {
-        static readonly CancellationTokenSource token = new();
+        static readonly CancellationTokenSource serverLifetimeToken = new();
 
         static TcpHandler? tcpHandler;
         static SignalTranslator? signalTranslator;
@@ -15,7 +15,7 @@ namespace ZPIServer
         public static int Main(string[] args)
         {
             StartServer();
-            while (!token.IsCancellationRequested)
+            while (!serverLifetimeToken.IsCancellationRequested)
             {
                 //server lifetime loop
                 Console.Write(">> ");
@@ -27,7 +27,8 @@ namespace ZPIServer
         }
         private static void OnCommandExecuted(object? sender, System.EventArgs e)
         {
-
+            if (sender is not null && sender is ShutdownCommand)
+                serverLifetimeToken.Cancel();
         }
 
         private static void StartServer()

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -12,8 +12,6 @@ namespace ZPIServer
         static TcpHandler? tcpHandler;
         static SignalTranslator? signalTranslator;
 
-        public static event EventHandler<CommandEventArgs>? OnCommandExecuted;
-
         public static int Main(string[] args)
         {
             StartServer();
@@ -27,8 +25,7 @@ namespace ZPIServer
             StopServer();
             return 0;
         }
-
-        private static void OnCommandExecutionInvoke(object? sender, CommandEventArgs e)
+        private static void OnCommandExecuted(object? sender, System.EventArgs e)
         {
 
         }
@@ -40,10 +37,10 @@ namespace ZPIServer
             tcpHandler.BeginListening();
             signalTranslator = new SignalTranslator();
             signalTranslator.BeginTranslating();
+
+            Command.OnExecuted += OnCommandExecuted;
+
             stopwatch.Stop();
-
-            OnCommandExecuted += OnCommandExecutionInvoke;
-
             Console.WriteLine($"Done! Server took {stopwatch.Elapsed.TotalMilliseconds} milliseconds to start up.");
         }
 
@@ -73,19 +70,22 @@ namespace ZPIServer
             if (command is null)
             {
                 command = new HelpCommand();
-                Console.WriteLine($"Command {words[0]} unrecognized.");
+                Console.WriteLine($"Command '{words[0]}' unrecognized.");
             }
             words.RemoveAt(0);
+
+            //Execute command
             command.SetArguments(words.ToArray());
             command.Execute();
         }
 
         private static void StopServer()
         {
+            Console.WriteLine("Shutting the server down.");
             signalTranslator?.StopTranslating();
             tcpHandler?.StopListening();
 
-            OnCommandExecuted -= OnCommandExecutionInvoke;
+            Command.OnExecuted -= OnCommandExecuted;
         }
     }
 }

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -25,7 +25,7 @@ namespace ZPIServer
             StopServer();
             return 0;
         }
-        private static void OnCommandExecuted(object? sender, System.EventArgs e)
+        private static void OnCommandExecuted(object? sender, CommandEventArgs e)
         {
             if (sender is not null && sender is ShutdownCommand)
                 serverLifetimeToken.Cancel();
@@ -49,16 +49,11 @@ namespace ZPIServer
         {
             //Sanitize input line
             if (line is null)
-            {
-                Console.WriteLine("Command was null.");
                 return;
-            }
+            
             List<string> words = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
             if (words.Count == 0)
-            {
-                Console.WriteLine("Command was empty.");
                 return;
-            }
 
             //Recognize command
             Command? command = words[0] switch

--- a/server/test/API/TcpHandlerTests.cs
+++ b/server/test/API/TcpHandlerTests.cs
@@ -29,7 +29,7 @@ public class TcpHandlerTests
         handler.BeginListening();
         int timesInvoked = 0;
         byte[] receivedBytes = new byte[1024];
-        IPAddress senderIp = null;
+        IPAddress? senderIp = null;
         string messageToSend = "Hello World!";
         int senderPort = 0;
         int localClientPort = -1;
@@ -37,7 +37,7 @@ public class TcpHandlerTests
         using (var clientMock = new TcpClient())
         {
             clientMock.Connect(IPAddress.Parse("127.0.0.1"), 25565);
-            localClientPort = ((IPEndPoint)clientMock.Client.LocalEndPoint).Port;
+            localClientPort = ((IPEndPoint)clientMock.Client.LocalEndPoint!).Port;
             EventHandler<TcpHandlerEventArgs> eventHandler = (sender, e) =>
             {
                 receivedBytes = e.Data;

--- a/server/test/Commands/HelpCommandTests.cs
+++ b/server/test/Commands/HelpCommandTests.cs
@@ -47,7 +47,7 @@ public class HelpCommandTests
 
     [Theory]
     [MemberData(nameof(GetInvalidArguments), MemberType = typeof(HelpCommandTests))]
-    static void CheckExecutionWithInvalidArguments(string?[] arguments)
+    static void CheckExecutionWithInvalidArguments(string?[]? arguments)
     {
         object? sendingCommand = null;
         EventHandler<CommandEventArgs> handler = (sender, e) =>

--- a/server/test/Commands/HelpCommandTests.cs
+++ b/server/test/Commands/HelpCommandTests.cs
@@ -9,11 +9,9 @@ public class HelpCommandTests
     static void CheckExecutionWithNoArguments()
     {
         object? sendingCommand = null;
-        Command? handledCommand = null;
         EventHandler<CommandEventArgs> handler = (sender, e) =>
         {
             sendingCommand = sender;
-            handledCommand = e.Command;
         };
         Command.OnExecuted += handler;
 
@@ -21,7 +19,6 @@ public class HelpCommandTests
         command.Execute();
 
         Assert.Equal(command, sendingCommand);
-        Assert.Equal(command, handledCommand);
 
         Command.OnExecuted -= handler;
     }
@@ -31,11 +28,9 @@ public class HelpCommandTests
     [InlineData(Command.ShutdownCommand)]
     static void CheckExecutionWithArguments(string argument)
     {
-        Command? handledCommand = null;
         object? sendingCommand = null;
         EventHandler<CommandEventArgs> handler = (sender, e) =>
         {
-            handledCommand = e.Command;
             sendingCommand = sender;
         };
 
@@ -45,7 +40,6 @@ public class HelpCommandTests
         command.Execute();
 
         Assert.Equal(command, sendingCommand);
-        Assert.Equal(command, handledCommand);
         Assert.Equal(argument, command.CommandIdentifier);
 
         Command.OnExecuted -= handler;
@@ -55,11 +49,9 @@ public class HelpCommandTests
     [MemberData(nameof(GetInvalidArguments), MemberType = typeof(HelpCommandTests))]
     static void CheckExecutionWithInvalidArguments(string?[] arguments)
     {
-        Command? handledCommand = null;
         object? sendingCommand = null;
         EventHandler<CommandEventArgs> handler = (sender, e) =>
         {
-            handledCommand = e.Command;
             sendingCommand = sender;
         };
 
@@ -69,7 +61,6 @@ public class HelpCommandTests
         command.Execute();
 
         Assert.Equal(command, sendingCommand);
-        Assert.Equal(command, handledCommand);
         Assert.Null(command.CommandIdentifier);
 
         Command.OnExecuted -= handler;

--- a/server/test/Commands/HelpCommandTests.cs
+++ b/server/test/Commands/HelpCommandTests.cs
@@ -1,0 +1,89 @@
+﻿using ZPIServer.Commands;
+using ZPIServer.EventArgs;
+
+namespace ZPIServerTests.Commands;
+
+public class HelpCommandTests
+{
+    [Fact]
+    static void CheckExecutionWithNoArguments()
+    {
+        object? sendingCommand = null;
+        Command? handledCommand = null;
+        EventHandler<CommandEventArgs> handler = (sender, e) =>
+        {
+            sendingCommand = sender;
+            handledCommand = e.Command;
+        };
+        Command.OnExecuted += handler;
+
+        var command = new HelpCommand();
+        command.Execute();
+
+        Assert.Equal(command, sendingCommand);
+        Assert.Equal(command, handledCommand);
+
+        Command.OnExecuted -= handler;
+    }
+
+    [Theory]
+    [InlineData(Command.HelpCommand)]
+    [InlineData(Command.ShutdownCommand)]
+    static void CheckExecutionWithArguments(string argument)
+    {
+        Command? handledCommand = null;
+        object? sendingCommand = null;
+        EventHandler<CommandEventArgs> handler = (sender, e) =>
+        {
+            handledCommand = e.Command;
+            sendingCommand = sender;
+        };
+
+        Command.OnExecuted += handler;
+        var command = new HelpCommand();
+        command.SetArguments(argument);
+        command.Execute();
+
+        Assert.Equal(command, sendingCommand);
+        Assert.Equal(command, handledCommand);
+        Assert.Equal(argument, command.CommandIdentifier);
+
+        Command.OnExecuted -= handler;
+    }
+
+    [Theory]
+    [MemberData(nameof(GetInvalidArguments), MemberType = typeof(HelpCommandTests))]
+    static void CheckExecutionWithInvalidArguments(string?[] arguments)
+    {
+        Command? handledCommand = null;
+        object? sendingCommand = null;
+        EventHandler<CommandEventArgs> handler = (sender, e) =>
+        {
+            handledCommand = e.Command;
+            sendingCommand = sender;
+        };
+
+        Command.OnExecuted += handler;
+        var command = new HelpCommand();
+        command.SetArguments(arguments);
+        command.Execute();
+
+        Assert.Equal(command, sendingCommand);
+        Assert.Equal(command, handledCommand);
+        Assert.Null(command.CommandIdentifier);
+
+        Command.OnExecuted -= handler;
+    }
+
+    public static IEnumerable<object?[]> GetInvalidArguments()
+    {
+        yield return new object?[] { new string?[] { "", "", "", "   " } };
+        yield return new object?[] { new string?[] { "help", "help" } };
+        yield return new object?[] { new string?[] { "shutdown", "shutdown" } };
+        yield return new object?[] { new string?[] { "suhtdown" } };
+        yield return new object?[] { new string?[] { "hlep" } };
+        yield return new object?[] { new string?[] { "$" } };
+        yield return new object?[] { new string?[] { null } };
+        yield return new object?[] { new string?[] { null, null } };
+    }
+}

--- a/server/test/Commands/ShutdownCommandTests.cs
+++ b/server/test/Commands/ShutdownCommandTests.cs
@@ -9,11 +9,9 @@ public class ShutdownCommandTests
     static void CheckExecutionWithNoArguments()
     {
         object? sendingCommand = null;
-        Command? handledCommand = null;
         EventHandler<CommandEventArgs> handler = (sender, e) =>
         {
             sendingCommand = sender;
-            handledCommand = e.Command;
         };
         Command.OnExecuted += handler;
 
@@ -21,7 +19,6 @@ public class ShutdownCommandTests
         command.Execute();
 
         Assert.Equal(command, sendingCommand);
-        Assert.Equal(command, handledCommand);
         
         Command.OnExecuted -= handler;
     }

--- a/server/test/Commands/ShutdownCommandTests.cs
+++ b/server/test/Commands/ShutdownCommandTests.cs
@@ -1,0 +1,40 @@
+﻿using ZPIServer.Commands;
+using ZPIServer.EventArgs;
+
+namespace ZPIServerTests.Commands;
+
+public class ShutdownCommandTests
+{
+    [Fact]
+    static void CheckExecutionWithNoArguments()
+    {
+        object? sendingCommand = null;
+        Command? handledCommand = null;
+        EventHandler<CommandEventArgs> handler = (sender, e) =>
+        {
+            sendingCommand = sender;
+            handledCommand = e.Command;
+        };
+        Command.OnExecuted += handler;
+
+        var command = new ShutdownCommand();
+        command.Execute();
+
+        Assert.Equal(command, sendingCommand);
+        Assert.Equal(command, handledCommand);
+        
+        Command.OnExecuted -= handler;
+    }
+
+    //[Theory]
+    //static void CheckExecutionWithArguments()
+    //{
+
+    //}
+
+    //[Theory]
+    //static void CheckExecutionWithInvalidArguments()
+    //{
+
+    //}
+}


### PR DESCRIPTION
Konsola serwera może teraz odczytywać dane wejściowe w postaci komend z opcjonalnymi argumentami. Dwie pierwsze to `help` i `shutdown`.

Inne zmiany:
Pokazywanie komunikatów w konsoli przeniesiono do osobnej i opcjonalnej klasy `Logger`.
`TcpHandler` nie powinien już dublować bitów z poprzedniej wiadomości, jeśli przychodzący ciąg bitów był krótszy od poprzedniego.
`TcpHandler` nie powinien już się wywalać na łeb na szyję kiedy podłączone urządzenie nagle zerwie połączenie.
`SignalTranslator` może rozpoznawać lokalnie uruchomionego klienta PuTTY.
