### PR TITLE
Obsługa wielu połączeń na TcpHandler

### DIFF
--- a/ZPIServer.sln
+++ b/ZPIServer.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Elementy rozwiązania", "El
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		server\readme.md = server\readme.md
 	EndProjectSection
 EndProject
 Global

--- a/server/readme.md
+++ b/server/readme.md
@@ -1,0 +1,12 @@
+Jak uruchomiæ ten z³om:
+
+ 1. Komputer, który bêdzie serwerem musi dodaæ do swojej zapory ogniowej tak¹ zasadê:
+    - Po³¹czenia przychodz¹ce
+    - Pozwól na po³¹czenie
+    - Profile: Wszystkie
+    - Protokó³ TCP
+    - Specyficzne porty: 25565, 25566, 25567
+ 2. Edytuj `exampleStart.bat` tak aby serwer by³ uruchamiany na danym adresie IP i uruchom skrypt.
+    Alternatywnie, serwer mo¿na tez uruchomiæ z konsoli:
+     - `.\ZPIServer.exe` - uruchamia serwer na domyœlnym adresie IP \(127.0.0.1\).
+     - `.\ZPIServer.exe 192.168.1.1` - uruchamia serwer na podanym adresie IP. Jeœli adres jest z³y, uruchomi siê na adresie domyœlnym.

--- a/server/src/API/TcpHandler.cs
+++ b/server/src/API/TcpHandler.cs
@@ -128,9 +128,13 @@ public class TcpHandler
             }
         }
         if (inactiveListeners == _listeners.Length)
+        {
             throw new IOException($"All ports {nameof(TcpHandler)} was registered on were occupied!");
-        else
+        }
+        else if (inactiveListeners > 0)
+        {
             _logger?.WriteLine($"ALERT! Failed to start TcpListener on {inactiveListeners} port(s).", nameof(TcpHandler));
+        }
     }
 
     /// <summary>
@@ -243,16 +247,16 @@ public class TcpHandler
         {
             _logger?.WriteLine($"Running: {IsListening}", null);
             _logger?.WriteLine($"Logging: {_logger is not null}", null);
+            _logger?.WriteLine($"Connections initialized: {_connectionsInitialized}", null);
+            _logger?.WriteLine($"Connections fully handled: {_connectionsHandled}", null);
             _logger?.WriteLine($"Listeners:", null);
             for (int i = 0; i < _listeners.Length; i++)
             {
                 _logger?.WriteLine($"\tPort: {_listeners[i].GetLocalPort()}", null);
                 _logger?.WriteLine($"\tIsActive: {_listeners[i].IsActive()}", null);
                 _logger?.WriteLine($"\tTask Status: {_listenerTasks[i].Status}", null);
-                _logger?.WriteLine("---", null);
+                _logger?.WriteLine("\t --- ", null);
             }
-            _logger?.WriteLine($"Connections initialized: {_connectionsInitialized}", null);
-            _logger?.WriteLine($"Connections fully handled: {_connectionsHandled}", null);
         }
     }
 

--- a/server/src/API/TcpHandler.cs
+++ b/server/src/API/TcpHandler.cs
@@ -245,17 +245,18 @@ public class TcpHandler
     {
         if (sender is StatusCommand command && command.ClassArgument == StatusCommand.TcpHandlerArgument)
         {
-            _logger?.WriteLine($"Running: {IsListening}", null);
-            _logger?.WriteLine($"Logging: {_logger is not null}", null);
-            _logger?.WriteLine($"Connections initialized: {_connectionsInitialized}", null);
-            _logger?.WriteLine($"Connections fully handled: {_connectionsHandled}", null);
+            _logger?.WriteLine($"Running: {IsListening}");
+            _logger?.WriteLine($"Logging: {_logger is not null}");
+            _logger?.WriteLine($"Connections initialized: {_connectionsInitialized}");
+            _logger?.WriteLine($"Connections fully handled: {_connectionsHandled}");
             _logger?.WriteLine($"Listeners:", null);
             for (int i = 0; i < _listeners.Length; i++)
             {
-                _logger?.WriteLine($"\tPort: {_listeners[i].GetLocalPort()}", null);
-                _logger?.WriteLine($"\tIsActive: {_listeners[i].IsActive()}", null);
-                _logger?.WriteLine($"\tTask Status: {_listenerTasks[i].Status}", null);
-                _logger?.WriteLine("\t --- ", null);
+                _logger?.WriteLine($"\tAddress: {_listeners[i].GetLocalAddress()}");
+                _logger?.WriteLine($"\tPort: {_listeners[i].GetLocalPort()}");
+                _logger?.WriteLine($"\tIsActive: {_listeners[i].IsActive()}");
+                _logger?.WriteLine($"\tTask Status: {_listenerTasks[i].Status}");
+                _logger?.WriteLine("\t --- ");
             }
         }
     }
@@ -267,6 +268,11 @@ public static class TcpListenerExtensions
     public static int GetLocalPort(this TcpListener listener)
     {
         return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    public static IPAddress GetLocalAddress(this TcpListener listener)
+    {
+        return ((IPEndPoint)listener.LocalEndpoint).Address;
     }
 
     /// <summary>

--- a/server/src/API/TcpHandler.cs
+++ b/server/src/API/TcpHandler.cs
@@ -20,8 +20,10 @@ public class TcpHandler
 {
     private readonly CancellationTokenSource _token;
     private readonly Logger? _logger;
-    private readonly TcpListener _listener;
-    private readonly Task _listenerTask;
+    private readonly TcpListener[] _listeners;
+    private readonly Task[] _listenerTasks;
+
+    private readonly SemaphoreSlim _semaphore;
     private int _connectionsInitialized = 0;
     private int _connectionsHandled = 0;
 
@@ -31,22 +33,67 @@ public class TcpHandler
     public bool IsListening { get; private set; } = false;
 
     /// <summary>
+    /// Zwraca liczbę instancji <see cref="TcpListener"/>, na których <see cref="TcpHandler"/> nasłuchuje połączeń.
+    /// </summary>
+    public int ListenersCount => _listeners.Length;
+
+    /// <summary>
+    /// Zwraca liczbę <b>aktywnych</b> instancji <see cref="TcpListener"/>, na których <see cref="TcpHandler"/> nasłuchuje połączeń.
+    /// </summary>
+    public int ActiveListenersCount()
+    {
+        int activeListeners = 0;
+        foreach (var listener in _listeners)
+        {
+            if (listener.IsActive())
+                activeListeners++;
+        }
+        return activeListeners;
+    }
+
+    /// <summary>
     /// Wydarzenie, które jest inwokowane gdy <see cref="TcpHandler"/> otrzyma pełny ciąg bajtów z nasłuchiwanego portu.
     /// </summary>
     public static event EventHandler<TcpHandlerEventArgs>? OnSignalReceived;
 
-    public TcpHandler(IPAddress address, int listenPort, Logger? logger = null)
+    public TcpHandler(IPAddress address, int listenPort, Logger? logger = null) :
+        this(address, new int[] { listenPort }, logger)
     {
-        _token = new CancellationTokenSource();
-        _logger = logger;
-        _listener = new TcpListener(address, listenPort);
-        _listenerTask = new Task(async () =>
+    }
+
+    public TcpHandler(IPAddress address, int[] listenPorts, Logger? logger = null)
+    {
+        if (listenPorts is null)
+            throw new ArgumentException(null, nameof(listenPorts));
+        if (listenPorts.Length == 0)
+            throw new ArgumentException($"{nameof(listenPorts)} is empty.");
+        if (listenPorts.Distinct().Count() != listenPorts.Length)
+            throw new ArgumentException($"{nameof(listenPorts)} contained duplicate port numbers.");
+        foreach (var port in listenPorts)
         {
-            while (!_token.IsCancellationRequested)
+            if (port < 1024 || 65535 < port)
+                throw new ArgumentException($"{nameof(listenPorts)} contained an invalid TCP port number.");
+        }
+
+        _token = new CancellationTokenSource();
+        _semaphore = new SemaphoreSlim(1, 1);
+        _logger = logger;
+        _listeners = new TcpListener[listenPorts.Length];
+        _listenerTasks = new Task[listenPorts.Length];
+
+        for (int i = 0; i < listenPorts.Length; i++)
+        {
+            int index = i;
+            _listeners[index] = new TcpListener(address, listenPorts[index]);
+            _listenerTasks[index] = new Task(async () =>
             {
-                await HandleConnectionAsync();
-            }
-        });
+                while (!_token.IsCancellationRequested)
+                {
+                    await HandleConnectionAsync(_listeners[index]);
+                }
+            });
+        }
+
         Command.OnExecuted += ShowStatus;
     }
 
@@ -56,25 +103,34 @@ public class TcpHandler
     }
 
     /// <summary>
-    /// Pobiera obecną wartość <see cref="Settings.TcpListeningPorts"/> i rozpoczyna nasłuch na podanych portach.
+    /// Pobiera obecną wartość <see cref="Settings.TcpListeningPorts"/> i rozpoczyna nasłuch na podanych portach. Jeżeli jeden z portów okaże się być zajętym, <see cref="TcpHandler"/> kontynuuje pracę bez nasłuchu na danym porcie i informuje o tym fakcie w <see cref="Logger"/>ze.<br/>
+    /// Jeżeli wszystkie porty jakie zostały pobrane okażą się zajęte, wyjątek <see cref="IOException"/> jest rzucony.
     /// </summary>
     public void BeginListening()
     {
         if (IsListening)
             return;
 
-        try
+        _logger?.WriteLine("Starting up.", nameof(TcpHandler));
+        IsListening = true;
+        int inactiveListeners = 0;
+        for (int i = 0; i < _listeners.Length; i++)
         {
-            _logger?.WriteLine("Starting up.", nameof(TcpHandler));
-            IsListening = true;
-            _listener.Start();
-            _listenerTask.Start();
+            try
+            {
+                _listeners[i].Start();
+                _listenerTasks[i].Start();
+            }
+            catch (SocketException)
+            {
+                _logger?.WriteLine($"Could not start the TcpListener on port {_listeners[i].GetLocalPort()} - port already in use! {nameof(TcpHandler)} won't be able to listen for connections on that port.", nameof(TcpHandler));
+                inactiveListeners++;
+            }
         }
-        catch (Exception ex)
-        {
-            StopListening();
-            _logger?.WriteLine(ex.ToString(), nameof(TcpHandler));
-        }
+        if (inactiveListeners == _listeners.Length)
+            throw new IOException($"All ports {nameof(TcpHandler)} was registered on were occupied!");
+        else
+            _logger?.WriteLine($"ALERT! Failed to start TcpListener on {inactiveListeners} port(s).", nameof(TcpHandler));
     }
 
     /// <summary>
@@ -87,22 +143,32 @@ public class TcpHandler
 
         _logger?.WriteLine("Shutting down.", nameof(TcpHandler));
         _token.Cancel();
-        _listenerTask.Wait();
-        _listener.Stop();
+        foreach (var unstartedTask in _listenerTasks)
+        {
+            //Starting unstarted tasks after signaling cancellation through a token, so that they will immediately run into a while() condition and finish execution without ever invoking HandleConnectionAsync()
+            if (unstartedTask.Status == TaskStatus.Created)
+                unstartedTask.Start();
+        }
+        Task.WaitAll(_listenerTasks);
+        foreach (var listener in _listeners)
+            listener.Stop();
         IsListening = false;
     }
 
-    private async Task HandleConnectionAsync()
+    private async Task HandleConnectionAsync(TcpListener listener)
     {
-        _logger?.WriteLine($"Ready to accept connection on port {((IPEndPoint)_listener.LocalEndpoint).Port}.", nameof(TcpHandler));
+        _logger?.WriteLine($"Ready to accept connection on port {listener.GetLocalPort()}.", nameof(TcpHandler));
         try
         {
-            using TcpClient incomingClient = await _listener.AcceptTcpClientAsync(_token.Token);
+            using TcpClient incomingClient = await listener.AcceptTcpClientAsync(_token.Token);
             IPEndPoint clientEndPoint = (IPEndPoint)incomingClient.Client.RemoteEndPoint!;
             IPAddress clientAddress = clientEndPoint.Address;
             int clientPort = clientEndPoint.Port;
             _logger?.WriteLine($"Accepted connection from {clientAddress}:{clientPort}.", nameof(TcpHandler));
+
+            await _semaphore.WaitAsync();
             _connectionsInitialized++;
+            _semaphore.Release();
 
             using var stream = incomingClient.GetStream();
             int receivedBytesCount;
@@ -130,22 +196,26 @@ public class TcpHandler
                 buffer = new byte[bufferLength];
 
                 //Log that shit
-                _logger?.WriteLine($"Received {sanitizedBuffer.Count} bytes from {clientAddress}:{clientPort} on port {((IPEndPoint)_listener.LocalEndpoint).Port}.", nameof(TcpHandler));
+                _logger?.WriteLine($"Received {sanitizedBuffer.Count} bytes from {clientAddress}:{clientPort} on port {listener.GetLocalPort()}.", nameof(TcpHandler));
             }
-            _logger?.WriteLine($"Closed the connection from {clientAddress}:{clientEndPoint.Port}.", nameof(TcpHandler));
+            _logger?.WriteLine($"Closed the connection from {clientAddress}:{clientPort}.", nameof(TcpHandler));
             OnSignalReceived?.Invoke(this, new TcpHandlerEventArgs(clientAddress, clientPort, fullMessage.ToArray()));
+
+            await _semaphore.WaitAsync();
             _connectionsHandled++;
+            _semaphore.Release();
         }
         catch (IOException ex)
         {
             //Usually thrown when the other end abruptly closes the connection
+            _logger?.WriteLine($"IOException thrown on port {listener.GetLocalPort()}.", nameof(TcpHandler));
             _logger?.WriteLine($"{ex.Message}.", nameof(TcpHandler));
         }
         catch (OperationCanceledException)
         {
             if (_token.IsCancellationRequested)
             {
-                _logger?.WriteLine($"Cancelling connection handling due to cancellation token.", nameof(TcpHandler));
+                _logger?.WriteLine($"Cancelling connection handling on port {listener.GetLocalPort()} due to cancellation token.", nameof(TcpHandler));
                 return;
             }
             else
@@ -157,7 +227,7 @@ public class TcpHandler
         {
             if (_token.IsCancellationRequested)
             {
-                _logger?.WriteLine($"Cancelling connection handling due to cancellation token.", nameof(TcpHandler));
+                _logger?.WriteLine($"Cancelling connection handling on port {listener.GetLocalPort()} due to cancellation token.", nameof(TcpHandler));
                 return;
             }
             else
@@ -169,16 +239,39 @@ public class TcpHandler
 
     private void ShowStatus(object? sender, CommandEventArgs e)
     {
-        if (sender is StatusCommand command && command.ClassArgument == StatusCommand.SignalTranslatorArgument)
+        if (sender is StatusCommand command && command.ClassArgument == StatusCommand.TcpHandlerArgument)
         {
-            var endPoint = (IPEndPoint)_listener.LocalEndpoint;
             _logger?.WriteLine($"Running: {IsListening}", null);
             _logger?.WriteLine($"Logging: {_logger is not null}", null);
-            _logger?.WriteLine($"Listening on: {endPoint.Address}", null);
-            _logger?.WriteLine($"\t{endPoint.Port}", null);
-            _logger?.WriteLine($"ListenerTask: {_listenerTask.Status}", null);
+            _logger?.WriteLine($"Listeners:", null);
+            for (int i = 0; i < _listeners.Length; i++)
+            {
+                _logger?.WriteLine($"\tPort: {_listeners[i].GetLocalPort()}", null);
+                _logger?.WriteLine($"\tIsActive: {_listeners[i].IsActive()}", null);
+                _logger?.WriteLine($"\tTask Status: {_listenerTasks[i].Status}", null);
+                _logger?.WriteLine("---", null);
+            }
             _logger?.WriteLine($"Connections initialized: {_connectionsInitialized}", null);
             _logger?.WriteLine($"Connections fully handled: {_connectionsHandled}", null);
         }
+    }
+
+}
+
+public static class TcpListenerExtensions
+{
+    public static int GetLocalPort(this TcpListener listener)
+    {
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    /// <summary>
+    /// <see href="https://stackoverflow.com/a/59482929/21342746"/>
+    /// </summary>
+    /// <param name="listener"></param>
+    /// <returns></returns>
+    public static bool IsActive(this TcpListener listener)
+    {
+        return listener.Server.IsBound;
     }
 }

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -18,24 +18,24 @@ public class HelpCommand : Command
             switch (CommandIdentifier)
             {
                 case Help:
-                    _logger?.WriteLine(GetHelp(), null);
+                    _logger?.WriteLine(GetHelp());
                     break;
                 case Shutdown:
-                    _logger?.WriteLine(new ShutdownCommand(_logger).GetHelp(), null);
+                    _logger?.WriteLine(new ShutdownCommand(_logger).GetHelp());
                     break;
                 case Status:
-                    _logger?.WriteLine(new StatusCommand(_logger).GetHelp(), null);
+                    _logger?.WriteLine(new StatusCommand(_logger).GetHelp());
                     break;
                 default:
                     CommandIdentifier = null;
-                    _logger?.WriteLine("Unrecognized command.", null);
-                    _logger?.WriteLine(GetAvailableCommands(), null);
+                    _logger?.WriteLine("Unrecognized command.");
+                    _logger?.WriteLine(GetAvailableCommands());
                     break;
             }
         }
         else
         {
-            _logger?.WriteLine(GetAvailableCommands(), null);
+            _logger?.WriteLine(GetAvailableCommands());
         }
         Invoke(this, new CommandEventArgs());
     }
@@ -61,7 +61,7 @@ public class HelpCommand : Command
         }
         else if (arguments.Length > 1)
         {
-            _logger?.WriteLine("Too many arguments.", null);
+            _logger?.WriteLine("Too many arguments.");
         }
     }
 

--- a/server/src/Commands/HelpCommand.cs
+++ b/server/src/Commands/HelpCommand.cs
@@ -70,7 +70,7 @@ public class HelpCommand : Command
         var builder = new StringBuilder();
         builder.AppendLine(Help + " [command]");
         builder.AppendLine(Shutdown);
-        builder.AppendLine(Status + $" [{StatusCommand.TcpHandlerArgument}/{StatusCommand.TcpHandlerArgument}]");
+        builder.AppendLine(Status + $" [{StatusCommand.SignalTranslatorArgument}/{StatusCommand.TcpHandlerArgument}]");
         return builder.ToString();
     }
 }

--- a/server/src/Commands/Logger.cs
+++ b/server/src/Commands/Logger.cs
@@ -44,7 +44,7 @@ public class Logger
         };
         if (command is null)
         {
-            WriteLine($"Command '{words[0]}' unrecognized. Type '{Command.Help}' to get all available commands.", null);
+            WriteLine($"Command '{words[0]}' unrecognized. Type '{Command.Help}' to get all available commands.");
         }
         words.RemoveAt(0);
 

--- a/server/src/Commands/StatusCommand.cs
+++ b/server/src/Commands/StatusCommand.cs
@@ -21,18 +21,18 @@ public class StatusCommand : Command
             {
                 case TcpHandlerArgument:
                 case SignalTranslatorArgument:
-                    _logger?.WriteLine($"Status of {ClassArgument}:", null);
+                    _logger?.WriteLine($"Status of {ClassArgument}:");
                     break;
                 default:
-                    _logger?.WriteLine("Unrecognized argument.", null);
-                    _logger?.WriteLine(GetHelp(), null);
+                    _logger?.WriteLine("Unrecognized argument.");
+                    _logger?.WriteLine(GetHelp());
                     break;
             }
         }
         else
         {
-            _logger?.WriteLine($"{Command.Status} requires 1 argument.", null);
-            _logger?.WriteLine(GetHelp(), null);
+            _logger?.WriteLine($"{Command.Status} requires 1 argument.");
+            _logger?.WriteLine(GetHelp());
         }
         Invoke(this, new EventArgs.CommandEventArgs());
     }
@@ -63,7 +63,7 @@ public class StatusCommand : Command
         }
         else if (arguments.Length > 1)
         {
-            _logger?.WriteLine("Too many arguments.", null);
+            _logger?.WriteLine("Too many arguments.");
         }
     }
 }

--- a/server/src/Program.cs
+++ b/server/src/Program.cs
@@ -44,12 +44,12 @@ namespace ZPIServer
             Command.OnExecuted += OnCommandExecuted;
 
             stopwatch.Stop();
-            logger.WriteLine($"Done! {double.Round(stopwatch.Elapsed.TotalMilliseconds)} milliseconds elapsed.", null);
+            logger.WriteLine($"Done! {double.Round(stopwatch.Elapsed.TotalMilliseconds)} milliseconds elapsed.");
         }
 
         private static void StopServer()
         {
-            logger?.WriteLine("Shutting the server down.", null);
+            logger?.WriteLine("Shutting the server down.");
             
             Command.OnExecuted -= OnCommandExecuted;
 

--- a/server/src/Settings.cs
+++ b/server/src/Settings.cs
@@ -6,9 +6,9 @@ public static class Settings
 {
     /// <summary>
     /// Tabela portów, na których <see cref="API.TcpHandler"/> będzie nasłuchiwał przychodzących połączeń od kamer i użytkowników.<br/>
-    /// Domyślny port to 25565.
+    /// Domyślne porty to 25565, 25566, 25567.
     /// </summary>
-    public static int TcpListeningPort { get; set; } = 25565;
+    public static int[] TcpListeningPort { get; set; } = new int[] { 25565, 25566, 25567 };
 
     /// <summary>
     /// Adres IP serwera w sieci lokalnej. Na tym adresie będą nasłuchiwane porty.<br/>
@@ -18,7 +18,7 @@ public static class Settings
 
     public static void ResetToDefault()
     {
-        TcpListeningPort = 25565;
+        TcpListeningPort = new int[] { 25565, 25566, 25567 };
         ServerAddress = IPAddress.Parse("127.0.0.1");
     }
 }

--- a/server/src/ZPIServer.csproj
+++ b/server/src/ZPIServer.csproj
@@ -7,4 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Update="exampleStart.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/server/src/exampleStart.bat
+++ b/server/src/exampleStart.bat
@@ -1,0 +1,7 @@
+@REM Start on localhost "127.0.0.1"
+@REM .\ZPIServer.exe
+
+@REM Start on specified IP address
+.\ZPIServer.exe 192.168.1.1
+
+pause

--- a/server/test/API/TcpHandlerTests.cs
+++ b/server/test/API/TcpHandlerTests.cs
@@ -21,16 +21,63 @@ public class TcpHandlerTests
         Assert.False(handler.IsListening);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData(new int[] { })]
+    [InlineData(new int[] { 25565, 25565 })]
+    [InlineData(new int[] { 1023 })]
+    [InlineData(new int[] { 65536 })]
+    public static void CheckListenPortConditionsInConstructor(int[] ports)
+    {
+        IPAddress address = IPAddress.Parse("127.0.0.1");
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var handler = new TcpHandler(address, ports);
+        });
+    }
+
+    [Theory]
+    [InlineData(new int[] { 13131, 12345, 11131 })]
+    [InlineData(new int[] { 11111, 22222, 12345 })]
+    public static void CheckThatOccupiedPortsAreOmitted(int[] ports)
+    {
+        IPAddress address = IPAddress.Parse("127.0.0.1");
+        var portOccupant = new TcpListener(address, 12345);
+        portOccupant.Start();
+        var handler = new TcpHandler(address, ports);
+        handler.BeginListening();
+
+        Assert.Equal(ports.Length - 1, handler.ActiveListenersCount());
+        portOccupant.Stop();
+        handler.StopListening();
+    }
+
+    [Fact]
+    public static void CheckThatBeginListeningThrowsOnAllPortsOccupied()
+    {
+        int samePort = 13223;
+        IPAddress address = IPAddress.Parse("127.0.0.1");
+        var portOccupant = new TcpListener(address, samePort);
+        portOccupant.Start();
+        var handler = new TcpHandler(address, samePort);
+
+        Assert.Throws<IOException>(() =>
+        {
+            handler.BeginListening();
+        });
+    }
+
     //Ten test działa tylko w DebugMode (nie wiem czemu??)
     [Fact]
     public static void CheckMessagesAreComingThrough()
     {
         var handler = new TcpHandler(IPAddress.Parse("127.0.0.1"), 25565);
         handler.BeginListening();
+        string messageToSend = "Hello World!";
+
         int timesInvoked = 0;
         byte[] receivedBytes = new byte[1024];
         IPAddress? senderIp = null;
-        string messageToSend = "Hello World!";
         int senderPort = 0;
         int localClientPort = -1;
 
@@ -62,28 +109,106 @@ public class TcpHandlerTests
         Assert.Equal(1, timesInvoked);
     }
 
+    //Działa tylko podczas debugowania (nadal nie wiem czemu)
     [Fact]
-    public static void CheckPortsAreOccupied()
+    public static void CheckManyMessagesAreComingThrough()
     {
-        var handler = new TcpHandler(IPAddress.Parse("127.0.0.1"), 25565);
-        handler.BeginListening();
-        List<int> listeningPorts = GetCurrentlyListeningTcpPorts();
+        IPAddress address = IPAddress.Parse("127.0.0.1");
+        int[] ports = new int[] { 25565, 25566, 25567 };
+        const string messageToSend = "Hello World!";
 
-        Assert.Contains(25565, listeningPorts);
-        Assert.Throws<SocketException>(() =>
+        int timesInvoked = 0;
+        List<string> receivedMessages = new();
+        List<(IPAddress?, int)> connectedClientInfo = new();
+
+        //Create TcpHandler
+        var handler = new TcpHandler(address, ports);
+        handler.BeginListening();
+
+        //Create one TcpClient per handler's port and connect them to the server
+        var clientMocks = new TcpClient[ports.Length];
+        for (int i = 0; i < ports.Length; i++)
         {
-            var conflictingListener = new TcpListener(IPAddress.Parse("127.0.0.1"), 25565);
-            conflictingListener.Start();
-        });
+            clientMocks[i] = new TcpClient();
+            clientMocks[i].Connect(address, ports[i]);
+        }
+
+        //Subscribe to the event with a EventHandler that will fire once a full message has been received
+        //This event will modify variables which will be validated with Asserts later on
+        EventHandler<TcpHandlerEventArgs> eventHandler = (sender, e) =>
+        {
+            receivedMessages.Add(Encoding.UTF8.GetString(e.Data));
+            connectedClientInfo.Add((e.SenderIp, e.SenderPort));
+            timesInvoked++;
+        };
+        TcpHandler.OnSignalReceived += eventHandler;
+
+        //Send the bytes of messageToSend on each client
+        //Message will be appended with client's port to make sure all received messages are unique.
+        //Since mocks will be disposed with Close() method, their ports will be preserved separately
+        List<int> clientMockPorts = new();
+        foreach (var mock in clientMocks)
+        {
+            int mockPort = ((IPEndPoint)mock.Client.LocalEndPoint!).Port;
+            clientMockPorts.Add(mockPort);
+
+            byte[] message = Encoding.UTF8.GetBytes(messageToSend + mockPort);
+            using var stream = mock.GetStream();
+            stream.Write(message, 0, message.Length);
+        }
+
+        //Signal to close the TCP connection and dispose mocks
+        foreach (var mock in clientMocks)
+        {
+            mock.Close();
+        }
+
+        //Assert that everything went well
+        foreach (var clientMockPort in clientMockPorts)
+        {
+            Assert.Contains(messageToSend + clientMockPort, receivedMessages);
+            Assert.Contains((address, clientMockPort), connectedClientInfo);
+        }
+        Assert.Equal(3, timesInvoked);
+
+        TcpHandler.OnSignalReceived -= eventHandler;
+    }
+
+    [Theory]
+    [InlineData(new int[] { 25565 })]
+    [InlineData(new int[] { 25565, 25566 })]
+    [InlineData(new int[] { 25565, 25566, 25567 })]
+    public static void CheckPortsAreOccupied(int[] ports)
+    {
+        var handler = new TcpHandler(IPAddress.Parse("127.0.0.1"), ports);
+        handler.BeginListening();
+
+        List<int> listeningPorts = GetCurrentlyListeningTcpPorts();
+        foreach (var port in ports)
+        {
+            Assert.Contains(port, listeningPorts);
+            Assert.Throws<SocketException>(() =>
+            {
+                var conflictingListener = new TcpListener(IPAddress.Parse("127.0.0.1"), port);
+                conflictingListener.Start();
+            });
+            Assert.Equal(ports.Length, handler.ListenersCount);
+        }
 
         handler.StopListening();
         listeningPorts = GetCurrentlyListeningTcpPorts();
-        Assert.DoesNotContain(25565, listeningPorts);
+        foreach (var port in ports)
+        {
+            Assert.DoesNotContain(port, listeningPorts);
+        }
 
-        //Check if another TcpListener could use this port once TcpHandler stops
-        var anotherListener = new TcpListener(IPAddress.Parse("127.0.0.1"), 25565);
-        anotherListener.Start();
-        anotherListener.Stop();
+        //Check if another TcpListener could use those ports once TcpHandler stops
+        foreach (var port in ports)
+        {
+            var anotherListener = new TcpListener(IPAddress.Parse("127.0.0.1"), port);
+            anotherListener.Start();
+            anotherListener.Stop();
+        }
     }
 
     private static List<int> GetCurrentlyListeningTcpPorts()


### PR DESCRIPTION
Serwer może teraz nasłuchiwać kilka portów na raz.
Można go też uruchomić na adresach IP innych niż localhost poprzez uruchomienie go jak polecenie w CMD z pierwszym argumentem jako adres, np.: `.\ZPIServer.exe 192.168.1.1`